### PR TITLE
[rdomenzain/kafka-connect-ui] Add helm chart kafka-connect-ui

### DIFF
--- a/charts/kafka-connect-ui/Chart.yaml
+++ b/charts/kafka-connect-ui/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "0.9.7"
+description: A Helm chart for Kafka Connect UI on Kubernetes
+home: https://github.com/rdomenzain/charts/tree/main/charts/kafka-connect-ui
+maintainers:
+  - name: rdomenzain
+    url: https://github.com/rdomenzain/
+name: kafka-connect-ui
+sources:
+  - https://github.com/rdomenzain/helm-chart/tree/main/charts/kafka-connect-ui
+version: 1.0.0

--- a/charts/kafka-connect-ui/README.md
+++ b/charts/kafka-connect-ui/README.md
@@ -1,0 +1,60 @@
+# Kafka Connect UI
+
+This is a web tool for Kafka Connect for setting up and managing connectors for multiple connect clusters.
+
+## Introduction
+
+This chart bootstraps a [kafka-connect-ui](https://github.com/lensesio/kafka-connect-ui) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm repo add rdomenzain https://rdomenzain.github.io/helm-chart
+$ helm install --name my-release rdomenzain/kafka-connect-ui
+```
+
+The command deploys Kafka Connect UI on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Kafka Connect UI chart and their default values.
+
+| Parameter                        | Description                                                 | Default                  |
+| -------------------------------  | ----------------------------------------------------------- | ------------------------ |
+| replicaCount                     | desired number of controller pods                           | 1                        |
+| image.repository                 | controller container image repository                       | landoop/kafka-connect-ui |
+| image.tag                        | controller container image tag                              | 0.9.7                    |
+| image.pullPolicy                 | controller container image pull policy                      | IfNotPresent             |
+| nameOverride                     | String to override name template                            | ""                       |
+| fullnameOverride                 | String to fully override fullname template                  | ""                       |
+| service.type                     | ClusterIP, NodePort, or LoadBalancer                        | ClusterIP                |
+| service.port                     | Service external port                                       | 80                       |
+| ingress.enabled                  | Enable ingress controller resource                          | false                    |
+| ingress.hosts                    | Ingress resource hostnames                                  | null                     |
+| ingress.path                     | Ingress path                                                | /                        |
+| ingress.annotations              | Ingress annotations configuration                           | {}                       |
+| ingress.tls                      | Ingress TLS configuration                                   | null                     |
+| resources                        | Server resource requests and limits                         | {}                       |
+| nodeSelector                     | Node labels for pod assignment                              | {}                       |
+| tolerations                      | Toleration labels for pod assignment                        | []                       |
+| affinity                         | Affinity settings for pod assignment                        | {}                       |
+
+The above parameters map to the env variables defined in [kafka-connect-ui](https://github.com/lensesio/kafka-connect-ui).

--- a/charts/kafka-connect-ui/templates/NOTES.txt
+++ b/charts/kafka-connect-ui/templates/NOTES.txt
@@ -1,0 +1,18 @@
+1. Create a port-forward to the kafka-connect-ui:
+   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "kafka-connect-ui.fullname" . }} 8080:{{ .Values.service.port }}
+
+   Then open the ui in your browser:
+
+   open http://localhost:8080
+
+{{- if .Values.ingress.enabled }}
+Ingress is enabled:
+{{- range .Values.ingress.tls }}
+{{- range .hosts }}
+  open https://{{ . }}
+{{- end }}
+{{- end }}
+{{- range .Values.ingress.hosts }}
+  open http://{{ . }}
+{{- end }}
+{{- end }}

--- a/charts/kafka-connect-ui/templates/_helpers.tpl
+++ b/charts/kafka-connect-ui/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-connect-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-connect-ui.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-connect-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/kafka-connect-ui/templates/deployment.yaml
+++ b/charts/kafka-connect-ui/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kafka-connect-ui.fullname" . }}
+  labels:
+    app: {{ include "kafka-connect-ui.name" . }}
+    chart: {{ include "kafka-connect-ui.chart" . }}
+    release: {{ .Release.Name }}
+
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "kafka-connect-ui.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "kafka-connect-ui.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: CONNECT_URL
+          {{- if .Values.connectCluster.url }}
+            value: {{ .Values.connectCluster.url | quote }}
+          {{- else }}
+            value: "http://kafka-connect:8083"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/kafka-connect-ui/templates/ingress.yaml
+++ b/charts/kafka-connect-ui/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kafka-connect-ui.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "kafka-connect-ui.name" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" | trunc 63 }}
+    helm.sh/chart: {{ include "kafka-connect-ui.chart" . }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end }}
+{{- end }}

--- a/charts/kafka-connect-ui/templates/service.yaml
+++ b/charts/kafka-connect-ui/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-connect-ui.fullname" . }}
+  labels:
+    app: {{ include "kafka-connect-ui.name" . }}
+    chart: {{ include "kafka-connect-ui.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "kafka-connect-ui.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/kafka-connect-ui/values.yaml
+++ b/charts/kafka-connect-ui/values.yaml
@@ -1,0 +1,54 @@
+# Default values for kafka-connect-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: landoop/kafka-connect-ui
+  tag: 0.9.7
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+# If not set it uses default strimzi kafka-connect url #release-name-connect-cluster-connect-api
+connectCluster:
+  url: ""
+
+## Ingress configuration
+## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts: []
+  tls: []
+    # - secretName: kafka-connect-ui-tls
+    #   hosts:
+    #     - kafka-connect-ui.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Description of the change

This merge request adds helm chart `kafka-connect-ui`

### Benefits

<!-- What benefits will be realized by the code change? -->
This is a web tool for Kafka Connect for setting up and managing connectors for multiple connect clusters.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
See https://github.com/lensesio/kafka-connect-ui

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [rdomenzain/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](./../CONTRIBUTING.md#sign-your-work)
